### PR TITLE
feat: add invoice number patch for credit notes, and workspace for Incotex

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ In the **Item Doctype**:
 
 ![image (9)](https://github.com/user-attachments/assets/ee58bcb5-1a63-4176-881c-cd98847933bf)
 
-- if you have many related items, you can opt tpo add teh item tax template and HS code per Item Group, we have similar taxes table there.
+- if you have many related items, you can opt to add the item tax template and HS code per Item Group, we have similar taxes table there.
 
 When you create a Sales Invoice:
 
@@ -133,7 +133,5 @@ This ensures that each item sent to KRA via INCOTEX has the correct HS Code as r
     - A response is received and recorded, similar to a sales invoice.
 
 > ⚠️ If you're creating a **standalone credit note**, **manually enter** the `CU Invoice Number` from the original Sales Invoice to ensure successful submission.
-> ⚠️
-> Remember, when creating an invoice ID, it must not have any special characters, so you will have to define a new name. If not, you will create a new field, which will have a new sequence that can be used as an invoice number on the INCOTEX while maintaining the customer's normal numbering.(This has yet to be done.)
 
 Feel free to contribute.

--- a/tims_incotex/patches.txt
+++ b/tims_incotex/patches.txt
@@ -4,3 +4,4 @@
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
+tims_incotex.tims_incotex.patches.create_invoice_number

--- a/tims_incotex/tims_incotex/patches/create_invoice_number.py
+++ b/tims_incotex/tims_incotex/patches/create_invoice_number.py
@@ -1,0 +1,27 @@
+import re
+
+import frappe
+
+
+def execute():
+    """Set Invoice Number On Credit Notes"""
+
+    invoices = frappe.get_all(
+        "Sales Invoice",
+        filters={"invoice_number": ["in", [None, ""]], "status": "Return"},
+        fields=["name"],
+    )
+
+    if not invoices:
+        return
+
+    for invoice in invoices:
+        formatted_invoice_number = re.sub(r"[^a-zA-Z0-9]", "", invoice.name)
+
+        frappe.db.set_value(
+            "Sales Invoice",
+            invoice.name,
+            "invoice_number",
+            formatted_invoice_number,
+            update_modified=False,
+        )

--- a/tims_incotex/tims_incotex/workspace/tims_incotex/tims_incotex.json
+++ b/tims_incotex/tims_incotex/workspace/tims_incotex/tims_incotex.json
@@ -1,0 +1,104 @@
+{
+ "app": "tims_incotex",
+ "charts": [],
+ "content": "[{\"id\":\"E1K7kXsIDE\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">TIMs Incotex</span>\",\"col\":12}},{\"id\":\"swdgVrTdaP\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"TIMs Incotex Dashboard\",\"col\":3}},{\"id\":\"tL7PJU3sDz\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Tims Incotex Settings\",\"col\":3}},{\"id\":\"KT3jHQLrqv\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Integration Request\",\"col\":3}},{\"id\":\"z518w_qcfi\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Error Log\",\"col\":3}},{\"id\":\"nlg6WQySCM\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"RCAPuf-t4v\",\"type\":\"card\",\"data\":{\"card_name\":\"Setup and Configurations\",\"col\":4}}]",
+ "creation": "2025-07-26 10:12:14.358131",
+ "custom_blocks": [],
+ "docstatus": 0,
+ "doctype": "Workspace",
+ "for_user": "",
+ "hide_custom": 0,
+ "icon": "up",
+ "idx": 0,
+ "indicator_color": "green",
+ "is_hidden": 0,
+ "label": "TIMs Incotex",
+ "link_type": "DocType",
+ "links": [
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Setup and Configurations",
+   "link_count": 3,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Tims Incotex Settings",
+   "link_count": 0,
+   "link_to": "Tims Incotex Settings",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "TIMs HSCode",
+   "link_count": 0,
+   "link_to": "TIMs HSCode",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Item Tax Template",
+   "link_count": 0,
+   "link_to": "Item Tax Template",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  }
+ ],
+ "modified": "2025-07-26 10:34:51.918166",
+ "modified_by": "Administrator",
+ "module": "Tims Incotex",
+ "name": "TIMs Incotex",
+ "number_cards": [],
+ "owner": "Administrator",
+ "parent_page": "",
+ "public": 1,
+ "quick_lists": [],
+ "roles": [],
+ "sequence_id": 49.0,
+ "shortcuts": [
+  {
+   "color": "Grey",
+   "doc_view": "List",
+   "label": "TIMs Incotex Dashboard",
+   "link_to": "TIMS Incotex Dashboard",
+   "type": "Dashboard"
+  },
+  {
+   "color": "Red",
+   "doc_view": "List",
+   "label": "Error Log",
+   "link_to": "Error Log",
+   "stats_filter": "[]",
+   "type": "DocType"
+  },
+  {
+   "color": "Blue",
+   "doc_view": "List",
+   "label": "Tims Incotex Settings",
+   "link_to": "Tims Incotex Settings",
+   "stats_filter": "[]",
+   "type": "DocType"
+  },
+  {
+   "color": "Green",
+   "doc_view": "List",
+   "label": "Integration Request",
+   "link_to": "Integration Request",
+   "stats_filter": "[[\"Integration Request\",\"integration_request_service\",\"like\",\"%TIMS Incotex%\",false]]",
+   "type": "DocType"
+  }
+ ],
+ "title": "TIMs Incotex",
+ "type": "Workspace"
+}


### PR DESCRIPTION
- Add patch to set invoice numbers on past credit notes
- Register patch in patches.txt for post-model sync execution
- add TIMs Incotex workspace
- Update README.md