### PR TITLE
feat: validate Tax ID; avoid modified bump on invoice filing

### DIFF
--- a/tims_incotex/hooks.py
+++ b/tims_incotex/hooks.py
@@ -154,7 +154,10 @@ doc_events = {
         "on_submit": "tims_incotex.tims_incotex.api.sales_invoice.on_submit",
         "before_save": "tims_incotex.tims_incotex.api.sales_invoice.before_save",
         "before_cancel": "tims_incotex.tims_incotex.api.sales_invoice.prevent_cancel_signed_invoice",
-    }
+    },
+    "Customer": {
+        "before_save": "tims_incotex.tims_incotex.overrides.customer.before_save"
+    },
 }
 
 # Scheduled Tasks

--- a/tims_incotex/patches.txt
+++ b/tims_incotex/patches.txt
@@ -4,5 +4,5 @@
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
-tims_incotex.tims_incotex.patches.create_invoice_number
-tims_incotex.tims_incotex.patches.update_filed_invoices
+# tims_incotex.tims_incotex.patches.create_invoice_number
+# tims_incotex.tims_incotex.patches.update_filed_invoices

--- a/tims_incotex/tims_incotex/api/sales_invoice.py
+++ b/tims_incotex/tims_incotex/api/sales_invoice.py
@@ -110,6 +110,7 @@ class TimsInvoice:
                 "cu_invoice_date": frappe.utils.today(),
                 "is_filed": 1,
             },
+            update_modified=False,
         )
 
     def handle_failure(self, response_data):

--- a/tims_incotex/tims_incotex/overrides/customer.py
+++ b/tims_incotex/tims_incotex/overrides/customer.py
@@ -1,0 +1,6 @@
+import frappe
+
+
+def before_save(doc, method=None):
+    if frappe.db.exists("Customer", {"tax_id": doc.tax_id}):
+        frappe.throw(f"Customer with Tax ID '{doc.tax_id}' already exists.")


### PR DESCRIPTION
- Validate Tax ID to prevent duplication
- Prevent unnecessary modified timestamp update when marking invoices as filed (update_modified=False)
- Temporarily disable post_model_sync patches in patches.txt