### PR TITLE
fix(customer): improve tax ID validation to prevent self-conflict

### DIFF
--- a/tims_incotex/tims_incotex/overrides/customer.py
+++ b/tims_incotex/tims_incotex/overrides/customer.py
@@ -2,5 +2,10 @@ import frappe
 
 
 def before_save(doc, method=None):
-    if frappe.db.exists("Customer", {"tax_id": doc.tax_id}):
+    if not doc.tax_id:
+        return
+
+    filters = {"tax_id": doc.tax_id, "name": ["!=", doc.name]}
+
+    if frappe.db.exists("Customer", filters):
         frappe.throw(f"Customer with Tax ID '{doc.tax_id}' already exists.")


### PR DESCRIPTION
- Add null check for tax_id before validation to prevent unnecessary processing
- Exclude current document from duplicate tax_id check to allow self-updates
- Fix issue where updating existing customer with same tax_id would throw error
- Improve validation logic to only check against other customers, not self